### PR TITLE
Correction de divers bugs avec Docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
     build: .
     volumes:
       - ./:/app
+      - /app/node_modules
     restart: always
     env_file: ./.env
     environment:

--- a/dockerfile
+++ b/dockerfile
@@ -2,10 +2,12 @@ FROM node:26-alpine
 
 WORKDIR /app
 
-COPY package.json /app
+COPY package.json ./
 
-RUN npm install
+RUN npm install --include=dev
+
+ENV NODE_ENV=development
 
 COPY ./ /app
 
-CMD ["npx", "nodemon", "--legacy-watch", "index.js"]
+CMD ["npm", "run", "dev"]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon index.js",
+    "dev": "nodemon --legacy-watch index.js",
     "test": "jest"
   },
   "author": "Pierre Braem",


### PR DESCRIPTION
Cette PR corrige deux bugs :
- Après le build avec Docker, npm demande d'installer `nodemon`
- Si il existait un dossier `node_modules` au moment de build l'image Docker, l'image ne se créer pas